### PR TITLE
Fix error when receiving code 204

### DIFF
--- a/lib/rest/wrappers/net_http_persistent_wrapper.rb
+++ b/lib/rest/wrappers/net_http_persistent_wrapper.rb
@@ -16,10 +16,16 @@ module Rest
 
         if response.header['content-encoding'].eql?('gzip')
           Rest.logger.debug 'GZIPPED'
-          sio = StringIO.new(response.body)
-          gz = Zlib::GzipReader.new(sio)
-          page = gz.read()
-          @body = page
+
+          if response.body
+            sio = StringIO.new(response.body)
+            gz = Zlib::GzipReader.new(sio)
+            page = gz.read()
+            @body = page
+          else
+            @body = nil
+          end
+
         end
       end
 


### PR DESCRIPTION
Code 204 indicates that a resource was deleted and that no body is being
returned. NetHttpPersistentResponseWrapper failed with a TypeError on
that response, since it assumed that the response would have a body.
This commit checks whether there is a body. If there isn't, it sets
@body to nil; otherwise it performs the same logic as before.
