### PR TITLE
fixes ruby warning

### DIFF
--- a/lib/rest/client.rb
+++ b/lib/rest/client.rb
@@ -59,7 +59,7 @@ module Rest
 
       @logger = Rest.logger
 
-      @gem = options[:gem] if options[:gem]
+      @gem = options[:gem]
 
       if @gem.nil?
         choose_best_gem()

--- a/lib/rest/version.rb
+++ b/lib/rest/version.rb
@@ -1,3 +1,3 @@
 module Rest
-  VERSION = "3.0.6"
+  VERSION = "3.0.7"
 end


### PR DESCRIPTION
```
/home/romand/.rvm/gems/ruby-2.1.1@iron_mq_ruby/gems/rest-3.0.6/lib/rest/client.rb:64: warning: instance variable @gem not initialized
```
